### PR TITLE
Issue003 non finite values

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/specfunc_MWE.npz filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.so
+
+*__pycache__*

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from ._test_nonfinitevalues import main as test_nonfinitevalues

--- a/tests/_test_nonfinitevalues.py
+++ b/tests/_test_nonfinitevalues.py
@@ -98,7 +98,7 @@ def main(
     for ii, ind in enumerate(np.ndindex(shape)):
 
         if verb is True:
-            msg = f"mpmath.hyp2f1() on value {ii} / {size}".ljust(just)
+            msg = f"mpmath.hyp2f1() on value {ii+1} / {size}".ljust(just)
             print(msg, end="\n" if ii == size-1 else "\r")
 
         out_mpmath[ind] = mpmath.hyp2f1(

--- a/tests/_test_nonfinitevalues.py
+++ b/tests/_test_nonfinitevalues.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import argparse
 
 
 import numpy as np
@@ -14,7 +15,6 @@ import mpmath
 
 # DEFAULT PATH and PFE (= Path/File.Ext)
 _PATH_HERE = os.path.dirname(__file__)
-_PFE_MWE = os.path.join(_PATH_HERE, 'specfunc_MWE.npz')
 _PATH_PROJECT = os.path.dirname(_PATH_HERE)
 
 
@@ -23,6 +23,13 @@ _PATH_PROJECT = os.path.dirname(_PATH_HERE)
 sys.path.insert(0, _PATH_PROJECT)
 import specfunc
 sys.path.pop(0)
+
+
+# default args
+_SUBSET = np.arange(0, 10)
+_PFE_MWE = os.path.join(_PATH_HERE, 'specfunc_MWE.npz')
+_VERB = True
+_DETAILS = None
 
 
 # ###############################
@@ -57,12 +64,15 @@ def main(
 
     # subset => must be a valid index
     if subset is not None:
+
+        # if from command line => list of str
+        subset = np.asarray(subset).astype(int)
         try:
             _ = np.ones((70000,), dtype=float)[subset]
             assert isinstance(_, np.ndarray)
         except Exception as err:
             msg = "Arg subset must be a valid index to a 1d array"
-            raise Exception(msg)
+            raise Exception(msg) from err
 
     # pfe_mwe => path/file.ext to existing mwe data file
     if pfe_mwe is None:
@@ -145,37 +155,65 @@ def main(
 
         # details
         if details is True:
-            vspec = out_specfunc[ifail].astype(str)
-            vmath = out_mpmath[ifail].astype(str)
-            spec_max = np.max(np.char.str_len(vspec))
-            math_max = np.max(np.char.str_len(vmath))
-            vspec = np.char.rjust(vspec, spec_max)
-            vmath = np.char.rjust(vmath, math_max)
-
-            lstr = [
-                f"\t- {ind0[ifail[ii]]}: {vspec[ii]} vs {vmath[ii]}"
-                for ii in range(ifail.sum())
-            ]
-            # lmax = np.max([len(ss) for ss in lstr])
-            msg_details = (
-                " "*len(f"\t\t- {ind0[-1]}")
-                + "specfunc\tvs\tout_mpmath\n"
-                + "\n".join(lstr)
-            )
+            msg_details = _details(out_specfunc, out_mpmath, ifail, ind0)
         else:
             msg_details = ''
 
         # msg
         msg = (
-            f"out_specfunc, of size = {size}, contains:\n"
+            f"For input array of size = {size}, specfunc returns:\n"
             f"\t- inf: {iinf.sum()}\n"
             f"\t- nan: {inan.sum()}\n"
-            f"\t- diff from mp.math: {idiff.sum()}\n"
+            f"\t- diff from mp.math: {idiff.sum()}\n\n"
             + msg_details
         )
         raise Exception(msg)
 
     return
+
+
+# ###############################
+# ###############################
+#       verb_details
+# ###############################
+
+
+def _details(out_specfunc, out_mpmath, ifail, ind0):
+    """ Return a msg with the mpmath vs specfunc result for each input value
+
+    """
+
+    # indfail
+    indfail = ind0[ifail]
+
+    # get values of mpmath and specfunc for fails, as char array
+    vspec = out_specfunc[ifail].astype(str)
+    vmath = out_mpmath[ifail].astype(str)
+
+    # justify for pretty column alignment
+    spec_max = np.max(np.char.str_len(vspec))
+    math_max = np.max(np.char.str_len(vmath))
+    vspec = np.char.rjust(vspec, spec_max)
+    vmath = np.char.rjust(vmath, math_max)
+
+    # build each line
+    lstr = [
+        f"\t- {indfail[ii]}: {vspec[ii]} vs {vmath[ii]}"
+        for ii in range(ifail.sum())
+    ]
+
+    # Concatenate with header
+    msg_details = (
+        "Details per input:\n"
+        "\tIndex".ljust(10)
+        + "specfunc".rjust(spec_max)
+        + " vs "
+        + "out_mpmath".ljust(math_max)
+        + "\n"
+        + "\n".join(lstr)
+    )
+
+    return msg_details
 
 
 # ###############################
@@ -186,4 +224,49 @@ def main(
 
 # in case we want to run from terminal
 if __name__ == '__main__':
-    main()
+
+    # -------------------
+    # initialize
+
+    # Parse input arguments
+    msg = main.__doc__
+
+    # Instanciate parser
+    parser = argparse.ArgumentParser(description=msg)
+
+    # -----------------------
+    # Define input arguments
+
+    parser.add_argument(
+        '-s', '--subset',
+        nargs='+',
+        type=str,
+        default='None',
+    )
+
+    # verb
+    parser.add_argument(
+        '-v', '--verb',
+        help='Whether to print progress',
+        required=False,
+        action='store_true',
+    )
+
+    # details
+    parser.add_argument(
+        '-d', '--details',
+        help='Whether to print detilas for each output value',
+        required=False,
+        action='store_true',
+    )
+
+    # -----------------
+    # Parse arguments
+
+    args = parser.parse_args()
+    kwdargs = dict(args._get_kwargs())
+
+    # -----------------
+    # Call function
+
+    main(**kwdargs)

--- a/tests/_test_nonfinitevalues.py
+++ b/tests/_test_nonfinitevalues.py
@@ -1,0 +1,142 @@
+import os
+import sys
+
+
+import numpy as np
+import mpmath
+
+
+# ###############################
+# ###############################
+#       DEFAULT
+# ###############################
+
+
+_PATH_HERE = os.path.dirname(__file__)
+_PFE_MWE = os.path.join(_PATH_HERE, 'specfunc_MWE.npz')
+_PATH_PROJECT = os.path.dirname(_PATH_HERE)
+
+
+# Make sure to load the local version of specfunc
+# => temporarilly insert local pah to sys.path in  1st position
+sys.path.insert(0, _PATH_PROJECT)
+import specfunc
+sys.path.pop(0)
+
+
+# ###############################
+# ###############################
+#       main
+# ###############################
+
+
+def main(
+    # subset of test data
+    subset=None,
+    # path/file.ext to MWE
+    pfe_mwe=None,
+    verb=None,
+):
+
+    # -------------------
+    # check inputs
+    # -------------------
+
+    # subset => must be a valid index
+    if subset is not None:
+        try:
+            _ = np.ones((70000,), dtype=float)[subset]
+            assert isinstance(_, np.ndarray)
+        except Exception as err:
+            msg = "Arg subset must be a valid index to a 1d array"
+            raise Exception(msg)
+
+    # pfe_mwe => path/file.ext to existing mwe data file
+    if pfe_mwe is None:
+        pfe_mwe = _PFE_MWE
+    assert os.path.isfile(pfe_mwe) and pfe_mwe.endswith('.npz')
+
+    # optional verbosity
+    if verb is None:
+        verb = True
+    assert isinstance(verb, bool)
+
+    # -------------------
+    # load local MWE file
+    # -------------------
+
+    dout = {k0: v0 for k0, v0 in np.load(pfe_mwe).items()}
+
+    # optional subset for test
+    if subset is not None:
+        for k0, v0 in dout.items():
+            dout[k0] = v0[subset]
+
+    # -------------------
+    # call specfunc.hyp2F1
+    # -------------------
+
+    if verb is True:
+        msg = "Computing specfunc.hyp2f1()"
+        print(msg)
+
+    out_specfunc = specfunc.hyp2f1(
+        dout['a'],
+        dout['b'],
+        dout['c'],
+        dout['z'],
+    )
+
+    # -------------------
+    # call npmath
+    # -------------------
+
+    shape = dout['a'].shape
+    size = dout['a'].size
+    just = len(f"mpmath.hyp2f1() on value {size} / {size}")
+    out_mpmath = np.zeros(shape, dtype=out_specfunc.dtype)
+    for ii, ind in enumerate(np.ndindex(shape)):
+
+        if verb is True:
+            msg = f"mpmath.hyp2f1() on value {ii} / {size}".ljust(just)
+            print(msg, end="\n" if ii == size-1 else "\r")
+
+        out_mpmath[ind] = mpmath.hyp2f1(
+            dout['a'][ind],
+            dout['b'][ind],
+            dout['c'][ind],
+            dout['z'][ind],
+        )
+
+    # -------------------
+    # compare values
+    # -------------------
+
+    # indexes of fails
+    iinf = np.isinf(out_specfunc)
+    inan = np.isnan(out_specfunc)
+    iok = ~(iinf | inan)
+    idiff = (out_specfunc[iok] != out_mpmath[iok])
+
+    # exception
+    if any(iinf | inan) or np.any(idiff):
+        msg = (
+            f"out_specfunc, of size = {size}, contains:\n"
+            f"\t- inf: {iinf.sum()}\n"
+            f"\t- nan: {inan.sum()}\n"
+            f"\t- diff from mp.math: {idiff.sum()}\n"
+        )
+        raise Exception(msg)
+
+    return
+
+
+# ###############################
+# ###############################
+#       __main__
+# ###############################
+
+
+# in case we want to run from terminal
+if __name__ == '__main__':
+    main()

--- a/tests/_test_nonfinitevalues.py
+++ b/tests/_test_nonfinitevalues.py
@@ -12,6 +12,7 @@ import mpmath
 # ###############################
 
 
+# DEFAULT PATH and PFE (= Path/File.Ext)
 _PATH_HERE = os.path.dirname(__file__)
 _PFE_MWE = os.path.join(_PATH_HERE, 'specfunc_MWE.npz')
 _PATH_PROJECT = os.path.dirname(_PATH_HERE)
@@ -37,6 +38,17 @@ def main(
     pfe_mwe=None,
     verb=None,
 ):
+    """ Compute hyp2f1() on a large set of test data
+
+    - with specfunc.hyp2f1()
+    - with mpmath.hyp2f1()
+
+    And checks for the presence of inf, nan or differences in the results
+    Raise an Exception detailing the number of each case, if any
+
+    Arg subset can be used to limit the analysis to a user-provided index
+
+    """
 
     # -------------------
     # check inputs
@@ -77,7 +89,7 @@ def main(
     # -------------------
 
     if verb is True:
-        msg = "Computing specfunc.hyp2f1()"
+        msg = "\nComputing specfunc.hyp2f1()"
         print(msg)
 
     out_specfunc = specfunc.hyp2f1(
@@ -99,7 +111,7 @@ def main(
 
         if verb is True:
             msg = f"mpmath.hyp2f1() on value {ii+1} / {size}".ljust(just)
-            print(msg, end="\n" if ii == size-1 else "\r")
+            print(msg, end="\n\n" if ii == size-1 else "\r")
 
         out_mpmath[ind] = mpmath.hyp2f1(
             dout['a'][ind],

--- a/tests/_test_nonfinitevalues.py
+++ b/tests/_test_nonfinitevalues.py
@@ -37,6 +37,7 @@ def main(
     # path/file.ext to MWE
     pfe_mwe=None,
     verb=None,
+    details=None,
 ):
     """ Compute hyp2f1() on a large set of test data
 
@@ -73,6 +74,11 @@ def main(
         verb = True
     assert isinstance(verb, bool)
 
+    # details
+    if details is None:
+        details = not (subset is None)
+    assert isinstance(details, bool)
+
     # -------------------
     # load local MWE file
     # -------------------
@@ -80,9 +86,11 @@ def main(
     dout = {k0: v0 for k0, v0 in np.load(pfe_mwe).items()}
 
     # optional subset for test
+    ind0 = np.arange(dout['a'].size)
     if subset is not None:
         for k0, v0 in dout.items():
             dout[k0] = v0[subset]
+        ind0 = ind0[subset]
 
     # -------------------
     # call specfunc.hyp2F1
@@ -129,14 +137,41 @@ def main(
     inan = np.isnan(out_specfunc)
     iok = ~(iinf | inan)
     idiff = (out_specfunc[iok] != out_mpmath[iok])
+    ifail = (iinf | inan)
+    ifail[iok] = idiff
 
     # exception
     if any(iinf | inan) or np.any(idiff):
+
+        # details
+        if details is True:
+            vspec = out_specfunc[ifail].astype(str)
+            vmath = out_mpmath[ifail].astype(str)
+            spec_max = np.max(np.char.str_len(vspec))
+            math_max = np.max(np.char.str_len(vmath))
+            vspec = np.char.rjust(vspec, spec_max)
+            vmath = np.char.rjust(vmath, math_max)
+
+            lstr = [
+                f"\t- {ind0[ifail[ii]]}: {vspec[ii]} vs {vmath[ii]}"
+                for ii in range(ifail.sum())
+            ]
+            # lmax = np.max([len(ss) for ss in lstr])
+            msg_details = (
+                " "*len(f"\t\t- {ind0[-1]}")
+                + "specfunc\tvs\tout_mpmath\n"
+                + "\n".join(lstr)
+            )
+        else:
+            msg_details = ''
+
+        # msg
         msg = (
             f"out_specfunc, of size = {size}, contains:\n"
             f"\t- inf: {iinf.sum()}\n"
             f"\t- nan: {inan.sum()}\n"
             f"\t- diff from mp.math: {idiff.sum()}\n"
+            + msg_details
         )
         raise Exception(msg)
 

--- a/tests/specfunc_MWE.npz
+++ b/tests/specfunc_MWE.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f6aed95f232796b1c5a44f649048753577447a43300cbfa2d079da17fd794e9
+size 3540934


### PR DESCRIPTION
Main changes:
---------------------

* `tests/` created with:
    - `__init__.py` to be able to import `tests`
    - `_test_nonfinitevalues.py` which contains the main function t load the test data and test it against `mpmath`
        - loads the data file
        - calls `specfunc.hyp2f1()` on it, array-wise
        - callas `mpmath.hyp2f1()` on it, element-wise in a loop
        - check the output and raise a Exception if any of the following happens:
            - `specfunc.hyp2f1()` returned infs
            - `specfunc.hyp2f1()` returned nans
            - `specfunc.hyp2f1()` returned values that differ from the output of `mpmath.hyp2f1()`
        - The exception msg details the number of each case
        - It is possible to ask to test only a subset of the tests data, by providing an index `subset`
             - if subset is None => all ~70.000 values are tested
             - if provided, subset must be a valid index to a 1d (~70.000,) array, such as to still get an array
             - typical example: a array of int indices
         - `details` will print, for each input, the output computed by `specfunc` vs `mpmath`
* `gitignore` created
* `.gitattributes` added because the test data file, being a binary, is tracked using [git-lfs](https://git-lfs.com/).


* Also implemented the possibility of calling directly from the command line using `argparse`, where
    - -s or --subset: specify a sequence of space-separated int (will be converted to array of int indices)
    - -v or --verb: for verbosity
    - -d or --details: for printing details of each result

Issues:
----------

Contributes to addressing issue #3 


Examples:
---------------


```python
#@ from the local dir
import tests 

# testing only the first 3 values
tests.test_nonfinitevalues(subset=np.r_[0,1,2].astype(int))

Computing specfunc.hyp2f1()
mpmath.hyp2f1() on value 3 / 3

---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 tests.test_nonfinitevalues(subset=(np.r_[0,1,2].astype(int),))

File ~/Projects/specfunc/tests/_test_nonfinitevalues.py:129, in main(subset, pfe_mwe, verb)
    122 if any(iinf | inan) or np.any(idiff):
    123     msg = (
    124         f"out_specfunc, of size = {size}, contains:\n"
    125         f"\t- inf: {iinf.sum()}\n"
    126         f"\t- nan: {inan.sum()}\n"
    127         f"\t- diff from mp.math: {idiff.sum()}\n"
    128     )
--> 129     raise Exception(msg)
    131 return

Exception: out_specfunc, of size = 3, contains:
	- inf: 3
	- nan: 0
	- diff from mp.math: 0
```

Also from the command line
```python
python tests/_test_nonfinitevalues.py -s 1 2 3 -d
Traceback (most recent call last):
  File "/home/didier/Projects/specfunc/tests/_test_nonfinitevalues.py", line 272, in <module>
    main(**kwdargs)
  File "/home/didier/Projects/specfunc/tests/_test_nonfinitevalues.py", line 170, in main
    raise Exception(msg)
Exception: For input array of size = 3, specfunc returns:
	- inf: 3
	- nan: 0
	- diff from mp.math: 0

Details per input:
	Index   specfunc vs out_mpmath                                  
	- 1:  (inf+infj) vs (1.0006557628494634-1.0806662935956569e-05j)
	- 2: (-inf-infj) vs (1.0009096560412776-1.9068751599007113e-05j)
	- 3:  (inf+infj) vs (1.0011423806385635-2.8114824250638458e-05j)

```


@fedro4 this should allow you to start testing / debugging
